### PR TITLE
Do not fail fast if a language container failed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: gentestmatrix
     strategy:
+      fail-fast: false
       matrix:
         toxenv: ${{fromJson(needs.gentestmatrix.outputs.matrix)}}
     steps:


### PR DESCRIPTION
Without this patch, a single failure stops all the build.
It might be useful to know more about all the issues, instead of
just one.

This fixes it by ensuring the matrix is not stopped early if
a problem with a language happens.
