### PR TITLE
Add venv for commands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         run: sudo apt update && sudo apt install jo tox
       - id: setmatrix
         run: |
-          stringified_matrix=$(tox -a | jo -a)
+          stringified_matrix=$(tox -a |grep -v venv| jo -a)
           echo "::set-output name=matrix::$stringified_matrix"
   test-containers:
     name: Test containers

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,7 @@ commands =
 [testenv:list-all]
 commands =
     m8s-list-containers
+
+[testenv:venv]
+passenv = *
+commands = {posargs}


### PR DESCRIPTION
Without this, one needs to enter the venv to run specific command
that are installed through setuptools entrypoints.

This is mildly annoying.

This fixes it by introducing a 'venv' environment, whose purpose
is only to accept commands.
